### PR TITLE
Added 't modify latest' extension

### DIFF
--- a/timebook/commands.py
+++ b/timebook/commands.py
@@ -885,8 +885,19 @@ Please use the date format \"YYYY-MM-DD HH:MM\""
 def modify(db, args):
     if len(args) < 1:
         raise exceptions.CommandError("You must select the ID number of an entry \
-of you'd like to modify.")
-    id = args[0]
+of you'd like to modify. Use 'modify latest' to modify the latest entry of the current sheet.")
+    if args[0] == "latest":
+        db.execute(u"""
+            SELECT id
+            FROM entry WHERE sheet = ?
+            ORDER BY id DESC LIMIT 1
+        """, (dbutil.get_current_sheet(db), ))
+        row = db.fetchone()
+        if not row:
+            raise exceptions.CommandError("No entries for modification found.")
+        id = row[0]
+    else:
+        id = args[0]
     db.execute(u"""
         SELECT start_time, end_time, description
         FROM entry WHERE id = ?

--- a/timebook/commands.py
+++ b/timebook/commands.py
@@ -1304,7 +1304,7 @@ def format_eu(db, sheet, where, show_ids=False, sdate=None, edate=None):
     dates = [d.strftime("%Y-%m-%d") for d in daterange(sdate, edate)]
     writer.writerow(["WP"] + dates)
 
-    for wp in range(1, 7):
+    for wp in range(1, 8):
         if wp in export_data:
             columns = export_data[wp]
         else:


### PR DESCRIPTION
Added 'latest' argument to modify command: 't modify latest' allows the user to directly change the latest entry of the current timesheet.
No need to do 't display --show-ids' to find out the id of the latest entry anymore.

Maybe I am the only one who uses the modify command only with the latest entry most of the time and finds searching for the latest id annoying. But maybe not ;-)